### PR TITLE
TAIR3-825: fix broken PhyloGenes → TAIR back-link

### DIFF
--- a/src/views/TreeDetail.vue
+++ b/src/views/TreeDetail.vue
@@ -832,7 +832,17 @@ export default {
           link = 'http://www.informatics.jax.org/accession/' + db_id
           break
         case 'AGI_LocusCode':
-          link = 'https://www.arabidopsis.org/locus?name=' + db_id
+          // TAIR3-825: upstream reference strings are "AGI_LocusCode:locus=<key>"
+          // (e.g. "AGI_LocusCode:locus=2120402"). The split above leaves
+          // db_id = "locus=<key>" — strip the "locus=" prefix and target
+          // TAIR's /locus?key=<numericKey> route. If a bare AGI name ever
+          // arrives (e.g. "AT4G20260"), fall back to /locus?name=.
+          if (db_id && db_id.startsWith('locus=')) {
+            link =
+              'https://www.arabidopsis.org/locus?key=' + db_id.slice(6)
+          } else {
+            link = 'https://www.arabidopsis.org/locus?name=' + db_id
+          }
           break
         case 'TAIR':
           // Handle cases like "TAIR:Publication:501785323|PMID:31170927"


### PR DESCRIPTION
## Summary

Fixes the PhyloGenes → TAIR half of [TAIR3-825](https://phoenixbioinformatics.atlassian.net/browse/TAIR3-825). The TAIR → PhyloGenes half lives in `tair3` and was fixed in https://github.com/tair/tair3/pull/309.

**Root cause:** `getReferenceLink` in `src/views/TreeDetail.vue` splits the upstream reference string on \`':'\` and uses the second segment verbatim as the `?name=` value. The Arabidopsis entries upstream carry the format `AGI_LocusCode:locus=<numericKey>` (e.g. `AGI_LocusCode:locus=2120402`), so the split produces `db_id = "locus=2120402"`. That string gets URL-encoded as `locus%3D2120402` and the final link becomes:

```
https://www.arabidopsis.org/locus?name=locus%3D2120402   ← 404
```

Also, `?name=` expects an AGI gene name like `AT4G20260`, not a numeric locus key — TAIR keys numeric ids under `?key=`.

**Fix:** strip the leading `locus=` if present, then use `?key=<numericKey>`. Fall back to `?name=<db_id>` if a bare AGI name ever arrives upstream.

## Reproduction (before this PR)

1. Open https://phylogenes.arabidopsis.org/tree/PTHR38522.
2. Find the PCAP1 row (Arabidopsis thaliana, AGI key 2120402).
3. Click the TAIR link → lands on `https://www.arabidopsis.org/locus?name=locus%3D2120402` → "Page not found".

After the fix the link resolves to `https://www.arabidopsis.org/locus?key=2120402`, which is TAIR's expected numeric-key locus route.

## Test plan

- [ ] Reviewer: on any tree with an Arabidopsis leaf (e.g. PTHR38522), click the TAIR link — should land on the locus page instead of 404.
- [ ] Reviewer: spot-check that the other reference types (`PMID`, `GO_REF`, `MGI`, `TAIR`, `DOI`, etc.) still build the same URLs they did before — this change only touches the `AGI_LocusCode` branch.

## Out of scope

- AGI locus code search on PhyloGenes (ticket also mentions this doesn't work) — separate issue, needs its own investigation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, isolated URL-construction change for `AGI_LocusCode` references in `getReferenceLink`, with a safe fallback to the prior `?name=` behavior.
> 
> **Overview**
> Fixes broken PhyloGenes → TAIR back-links for Arabidopsis references by updating `getReferenceLink` to detect `AGI_LocusCode:locus=<key>` values, strip the `locus=` prefix, and generate `https://www.arabidopsis.org/locus?key=<numericKey>` URLs.
> 
> If the reference is already a bare AGI gene name, it falls back to the previous `https://www.arabidopsis.org/locus?name=<db_id>` link format.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38853d53c252fab83203cd4c21ecf256b1b6f04a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->