### PR TITLE
TAIR3-825: fix broken gene-table TAIR back-link (use ?accession=)

### DIFF
--- a/src/components/table/TableD3.vue
+++ b/src/components/table/TableD3.vue
@@ -1018,9 +1018,20 @@ export default {
       let link_text = null
       switch (organism) {
         case 'Arabidopsis thaliana':
-          link_text =
-            'http://www.arabidopsis.org/servlets/TairObject?type=locus&name=' +
-            gene_id
+          // TAIR3-825: upstream gene_id for Arabidopsis entries arrives as
+          // "locus=<numericKey>" (e.g. "locus=2120402"). Building the legacy
+          // /servlets/TairObject?type=locus&name=locus=<key> URL produces a
+          // 404 because TAIR redirects to /locus?name=locus%3D<key>, which
+          // has the literal "locus=" inside the name param. Strip the
+          // "locus=" prefix and target the modern /locus?key=<numericKey>
+          // route. If a bare AGI name ever arrives (e.g. "AT4G20260"), fall
+          // back to /locus?name=<name>.
+          if (gene_id && gene_id.startsWith('locus=')) {
+            link_text =
+              'https://www.arabidopsis.org/locus?key=' + gene_id.slice(6)
+          } else {
+            link_text = 'https://www.arabidopsis.org/locus?name=' + gene_id
+          }
           break
         case 'Zea mays':
           link_text = 'https://www.maizegdb.org/gene_center/gene/' + gene_id

--- a/src/components/table/TableD3.vue
+++ b/src/components/table/TableD3.vue
@@ -1018,17 +1018,18 @@ export default {
       let link_text = null
       switch (organism) {
         case 'Arabidopsis thaliana':
-          // TAIR3-825: upstream gene_id for Arabidopsis entries arrives as
-          // "locus=<numericKey>" (e.g. "locus=2120402"). Building the legacy
-          // /servlets/TairObject?type=locus&name=locus=<key> URL produces a
-          // 404 because TAIR redirects to /locus?name=locus%3D<key>, which
-          // has the literal "locus=" inside the name param. Strip the
-          // "locus=" prefix and target the modern /locus?key=<numericKey>
-          // route. If a bare AGI name ever arrives (e.g. "AT4G20260"), fall
+          // TAIR3-825: upstream gene_id for Arabidopsis entries is the
+          // legacy tair_object_id, formatted as "locus=<objectId>"
+          // (e.g. "locus=2120402"). TAIR3 keys locus pages by a different
+          // internal locus_id (e.g. 127368 for AT4G20260), so we can't
+          // use ?key=<objectId>. Use ?accession=<objectId>, which hits
+          // TAIR3's /detail/locus/accession endpoint and resolves the
+          // tair_object_id to locus_id server-side before rendering.
+          // If a bare AGI name ever arrives (e.g. "AT4G20260"), fall
           // back to /locus?name=<name>.
           if (gene_id && gene_id.startsWith('locus=')) {
             link_text =
-              'https://www.arabidopsis.org/locus?key=' + gene_id.slice(6)
+              'https://www.arabidopsis.org/locus?accession=' + gene_id.slice(6)
           } else {
             link_text = 'https://www.arabidopsis.org/locus?name=' + gene_id
           }

--- a/src/views/TreeDetail.vue
+++ b/src/views/TreeDetail.vue
@@ -832,14 +832,16 @@ export default {
           link = 'http://www.informatics.jax.org/accession/' + db_id
           break
         case 'AGI_LocusCode':
-          // TAIR3-825: upstream reference strings are "AGI_LocusCode:locus=<key>"
-          // (e.g. "AGI_LocusCode:locus=2120402"). The split above leaves
-          // db_id = "locus=<key>" — strip the "locus=" prefix and target
-          // TAIR's /locus?key=<numericKey> route. If a bare AGI name ever
-          // arrives (e.g. "AT4G20260"), fall back to /locus?name=.
+          // TAIR3-825: upstream reference strings are
+          // "AGI_LocusCode:locus=<tair_object_id>". The numeric id is the
+          // legacy tair_object_id, NOT TAIR3's internal locus_id (they are
+          // distinct numbering systems). Route via ?accession=<objectId>
+          // so TAIR3's /detail/locus/accession endpoint resolves the
+          // tair_object_id → locus_id server-side. If a bare AGI name
+          // ever arrives (e.g. "AT4G20260"), fall back to /locus?name=.
           if (db_id && db_id.startsWith('locus=')) {
             link =
-              'https://www.arabidopsis.org/locus?key=' + db_id.slice(6)
+              'https://www.arabidopsis.org/locus?accession=' + db_id.slice(6)
           } else {
             link = 'https://www.arabidopsis.org/locus?name=' + db_id
           }


### PR DESCRIPTION
## Summary

Follow-up to #123 (same ticket, [TAIR3-825](https://phoenixbioinformatics.atlassian.net/browse/TAIR3-825)). That PR fixed the reference-panel link in `TreeDetail.vue`, but the user-facing link in the gene-table column (`TableD3.vue` — `getGeneIdLink`) is a separate code path and was still broken. Also corrects a wrong assumption in #123.

## What was wrong

Upstream PhyloGenes data identifies Arabidopsis rows as `locus=<n>`, e.g. `locus=2120402` for PCAP1. Two things broke:

1. **Gene-table link (this PR's new fix):** `TableD3.vue` built the legacy `http://www.arabidopsis.org/servlets/TairObject?type=locus&name=locus=2120402`, which TAIR redirects to `/locus?name=locus%3D2120402` → 404.

2. **Wrong assumption in #123:** that numeric id is the legacy `tair_object_id`, **not** TAIR3's internal `locus_id`. They are distinct numbering systems — PCAP1 is `tair_object_id=2120402` but `locus_id=127368`. The `?key=<id>` URL in #123 therefore also 404s. Corrected here in the same file.

## Fix

Strip the `locus=` prefix and route via `/locus?accession=<tair_object_id>`. That param hits TAIR3's existing `/detail/locus/accession` endpoint, which resolves server-side:

```sql
SELECT locus_id FROM locus WHERE tair_object_id = :accession
```

Applied in both places — `TableD3.vue::getGeneIdLink` (Arabidopsis case) and `TreeDetail.vue::getReferenceLink` (AGI_LocusCode case).

## Verification

Deployed to phylogenes prod on this branch, verified via real Chrome on https://phylogenes.arabidopsis.org/tree/PTHR38522:

| | Before | After |
|---|---|---|
| Gene-table TAIR link (PCAP1 row) | `http://www.arabidopsis.org/servlets/TairObject?type=locus&name=locus=2120402` → 404 | `https://www.arabidopsis.org/locus?accession=2120402` → renders AT4G20260 ✅ |

## Test plan

- [x] Confirmed link renders correctly and resolves to the real locus page (user-verified)
- [ ] After merge: confirm prod is switched back from the hotfix branch to `master` and the site still works
- [ ] Reviewer: spot-check a second Arabidopsis row on a different tree to confirm the fix isn't PCAP1-specific

## Out of scope

- Display text on the tree still reads `locus=2120402` (anchor text, not href). Cosmetic, pre-existing — separate follow-up if you want it to show the AGI name or gene symbol.
- AGI locus code search on PhyloGenes (ticket also mentions this) — different code path, different investigation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, isolated URL-construction changes for Arabidopsis TAIR links; main risk is any remaining unexpected `gene_id` formats causing incorrect link generation.
> 
> **Overview**
> Fixes broken TAIR backlinks for Arabidopsis entries by treating upstream `locus=<id>` values as legacy `tair_object_id`s and routing through `https://www.arabidopsis.org/locus?accession=<id>` instead of the old servlet URL / `?key=`.
> 
> Applies the same `?accession=` logic to the reference panel link generation in `TreeDetail.vue` for `AGI_LocusCode`, while keeping a fallback to `?name=` when a bare AGI locus name is provided.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec8e85ec2c7870b4d2731ba1d653f7bcd3881c94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->