### PR TITLE
PHG-381: load panther tree/MSA JSON through API instead of S3

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,6 @@
 VUE_APP_NAME = "phylogenes-prod"
 VUE_APP_API_URL = 'https://phylogenes-api.arabidopsis.org'
 VUE_APP_TOMCAT_URL = 'https://phylogenes-data.arabidopsis.org'
-VUE_APP_TREE_S3_URL = 'https://phg-panther-data-19.s3-us-west-2.amazonaws.com/'
-VUE_APP_MSA_S3_URL = 'https://phg-panther-msa-data-19.s3-us-west-2.amazonaws.com/'
 VUE_APP_S3_URL = 'https://phyloxml-17.s3-us-west-2.amazonaws.com/'
 VUE_APP_CSV_S3_URL = 'https://s3.us-west-2.amazonaws.com/phylogenes-csv-4.1/'
 VUE_APP_PUBLIC_URL = 'http://phylogenes-back.arabidopsis.org'

--- a/src/store/modules/treedata.js
+++ b/src/store/modules/treedata.js
@@ -2,8 +2,6 @@ import * as types from '../types_treedata'
 import axios from 'axios/index'
 
 const API_URL = process.env.VUE_APP_API_URL + '/api/panther'
-const TREE_S3_URL = process.env.VUE_APP_TREE_S3_URL
-const MSA_S3_URL = process.env.VUE_APP_MSA_S3_URL
 
 const state = {
   treedata: {
@@ -173,7 +171,7 @@ const actions = {
   },
   [types.TREE_ACTION_SET_PANTHER_TREE]: (context, payload) => {
     if (!payload) return
-    let treeUrl = TREE_S3_URL + payload + '.json'
+    let treeUrl = API_URL + '/tree-data/' + payload
     return new Promise((result, rej) => {
       axios({
         method: 'GET',
@@ -266,7 +264,7 @@ const actions = {
   },
   [types.TREE_ACTION_SET_MSADATA]: (context, payload) => {
     if (!payload) return
-    let msaUrl = MSA_S3_URL + payload + '.json'
+    let msaUrl = API_URL + '/msa-data/' + payload
     return new Promise((result, rej) => {
       axios({
         method: 'GET',


### PR DESCRIPTION
## Summary
- `src/store/modules/treedata.js` now loads tree JSON from `${API_URL}/tree-data/:id` and MSA JSON from `${API_URL}/msa-data/:id` instead of the two phg-panther S3 buckets — those buckets don't return permissive CORS headers and were blocking the browser.
- Drops the unused `VUE_APP_TREE_S3_URL` / `VUE_APP_MSA_S3_URL` from `.env.example`. Live `.env` files on deployed boxes can have those lines removed on next deploy (harmless leftovers either way).

## Paired backend PR
- tair/phylogenes-api#18 — must merge + deploy first, otherwise the UI will 404 on tree/MSA fetches.

## Linked
- https://phoenixbioinformatics.atlassian.net/browse/PHG-381

## Test plan
- [ ] Deploy API PR to UAT first, then this UI branch.
- [ ] Open a PhyloGenes family page (e.g. PTHR10000). The phylogenetic tree renders.
- [ ] Open the MSA panel — sequence rows render, frequency bar fills in.
- [ ] DevTools Network: requests for tree/MSA go to `phylogenes-api.arabidopsis.org/api/panther/tree-data/...` and `/msa-data/...` (200), not the S3 bucket.
- [ ] No CORS errors in console.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes core data-fetch URLs for tree/MSA rendering and now depends on new backend endpoints; misalignment or deployment order issues will surface as 404s/empty views.
> 
> **Overview**
> Switches Panther tree and MSA JSON loading in `src/store/modules/treedata.js` from direct S3 bucket URLs to API endpoints (`/api/panther/tree-data/:id` and `/api/panther/msa-data/:id`) to avoid browser CORS issues.
> 
> Cleans up configuration by removing the now-unused `VUE_APP_TREE_S3_URL` and `VUE_APP_MSA_S3_URL` entries from `.env.example`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01c460b2ed550fbcd39d49b0833476b7e977ad38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->