### PR TITLE
PHG-292: change GO annotation popup QuickGO links to AmiGO

### DIFF
--- a/src/views/TreeDetail.vue
+++ b/src/views/TreeDetail.vue
@@ -761,10 +761,12 @@ export default {
 
         curr_anno_data.code = code
         //~~source
-        curr_anno_data.source = 'QuickGO'
+        curr_anno_data.source = 'AmiGO'
         //~~sourceLink
+        //AmiGO's gene_product path is case sensitive, uniprotId arrives lowercased
         curr_anno_data.sourceLink =
-          'https://www.ebi.ac.uk/QuickGO/annotations?geneProductId=' + uniprotId
+          'https://amigo.geneontology.org/amigo/gene_product/UniProtKB:' +
+          uniprotId.toUpperCase()
 
         let uniqueId_matched_idx = annoList.findIndex(
           (l) => l.unique_id == curr_anno_data.unique_id

--- a/src/views/TreeDetail.vue
+++ b/src/views/TreeDetail.vue
@@ -746,7 +746,7 @@ export default {
         curr_anno_data.goTerm = a.goName
 
         //~~goTermLink
-        let goTermLink = 'http://amigo.geneontology.org/amigo/term/' + a.goId
+        let goTermLink = 'https://amigo.geneontology.org/amigo/term/' + a.goId
         curr_anno_data.goTermLink = goTermLink
         //~~code
         var code = ''


### PR DESCRIPTION
## Why this failed QA

PHG-292 was marked Development Done in Feb 2021 and sat in Ready for QA until it was QA'd on 2026-01-27 and failed. The reason: **the change was never actually made.**

- `git log --all -S'gene_product'` returns zero commits — the AmiGO gene_product URL has never existed in this repo on any branch.
- The live prod bundle still contains `a.source="QuickGO"`.

What caused the confusion: commit `dcdccf1` (Jul 2020, pre-dating the ticket) did move a link to AmiGO — but that was `goTermLink`, the **GO term** link. The ticket is about the **Source** column, which was never touched.

## Changes

`src/views/TreeDetail.vue`

1. Source column label `QuickGO` → `AmiGO`, and its link now points at AmiGO's `gene_product` page (the ticket's two asks).
2. Folded in: the sibling GO term link was still plain `http://` — a mixed-content risk on an HTTPS-only prod. Now `https://`.

## Case-sensitivity gotcha

`uniprotId` is lowercased upstream at line 715. QuickGO's `?geneProductId=` query param tolerated that; AmiGO's path does not:

- `.../gene_product/UniProtKB:Q5FVE4` → 200, renders the gene product page
- `.../gene_product/UniProtKB:q5fve4` → **404 Entity Not Found**

Hence the `.toUpperCase()`. Without it this would have failed QA a second time.

## Verification

- Both URL formats confirmed live in a browser (curl is bot-blocked by AmiGO with a 403).
- `goId` confirmed against the live API (`/api/panther/go_annotations/PTHR11945`) to already arrive prefixed, e.g. `GO:0000977` — so the term URL needs no reformatting.
- Build: exit 0. Compiled bundle contains both HTTPS AmiGO links and zero `QuickGO` occurrences.
- Lint: 19 errors in this file **both before and after** — all pre-existing (unused vars, empty catch blocks elsewhere). None introduced here.
- `'N/A'` edge case (row with no UniProt ID) returns early at the `!allAnnosForGene` guard before reaching the link code, so `.toUpperCase()` can't hit a non-string.

## Note for reviewers

Other external links in this file are still plain `http://` (MGI, FlyBase, CGD, WormBase, ZFIN, and `geneontology.org` in `TableD3.vue`). Left alone as out of scope for PHG-292, but worth a follow-up ticket.

https://phoenixbioinformatics.atlassian.net/browse/PHG-292

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized display/link changes in the annotation popup only; no auth, data, or API behavior changes.
> 
> **Overview**
> Updates the **GO annotation popup** in `TreeDetail.vue` so external links match PHG-292: the **Source** column now shows **AmiGO** and links to AmiGO’s `gene_product` page for the UniProt entry instead of QuickGO’s annotation query URL.
> 
> The **GO term** link is switched to **`https://`** on the same AmiGO term path to avoid mixed content on HTTPS prod. **`uniprotId.toUpperCase()`** is applied when building the gene-product URL because AmiGO’s path is case-sensitive and the ID is lowercased earlier in the click handler.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a128fdb76495698f59f916967443fba4830b1b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->